### PR TITLE
EIP-3475 stagnant (2021-Dec-5th@00.41.19)

### DIFF
--- a/EIPS/eip-3475.md
+++ b/EIPS/eip-3475.md
@@ -5,7 +5,7 @@ author: Yohji Sakamoto (@sgmfinance)
 discussions-to: https://github.com/ethereum/EIPs/issues/3467
 type: Standards Track
 category: ERC
-status: Draft
+status: Stagnant
 created: 2021-04-05
 ---
 


### PR DESCRIPTION
This EIP has not been active since (2021-Jun-1st@23.54.56); which, is greater than the allowed time of 6 months.

 authors: @sgmfinance 
